### PR TITLE
Add center-scaling and landmark tower

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/LandmarkTower.meta
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/LandmarkTower.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8544b31eeeca485aa34c763ed789436b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/LandmarkTower/LandmarkTower.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/LandmarkTower/LandmarkTower.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace Demo
+{
+    // Very simple grammar that stacks prefabs to create a landmark skyscraper.
+    // The tower consists of an optional base, a repeating middle section and a top element.
+    public class LandmarkTower : Shape
+    {
+        public GameObject basePrefab;
+        public GameObject middlePrefab;
+        public GameObject topPrefab;
+        public int middleLevels = 20;
+
+        protected override void Execute()
+        {
+            float y = 0f;
+            if (basePrefab != null)
+            {
+                SpawnPrefab(basePrefab, new Vector3(0, y, 0));
+                y += 1f;
+            }
+
+            for (int i = 0; i < middleLevels; i++)
+            {
+                if (middlePrefab != null)
+                {
+                    SpawnPrefab(middlePrefab, new Vector3(0, y, 0));
+                }
+                y += 1f;
+            }
+
+            if (topPrefab != null)
+            {
+                SpawnPrefab(topPrefab, new Vector3(0, y, 0));
+            }
+        }
+    }
+}

--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/LandmarkTower/LandmarkTower.cs.meta
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/LandmarkTower/LandmarkTower.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 442ba3d5bc71422082ffd5b4521cf4ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
@@ -1,0 +1,106 @@
+using UnityEngine;
+
+namespace Demo
+{
+    // Generates a cyberpunk-inspired city block using modular prefabs.
+    // Buildings near the center are taller and shrink in height towards the edges.
+    // One landmark building can be spawned in the center.
+    public class CyberCityBlockGenerator : MonoBehaviour
+    {
+        [Tooltip("Number of blocks along the X axis")]
+        public int width = 6;
+        [Tooltip("Number of blocks along the Z axis")]
+        public int depth = 6;
+        [Tooltip("Spacing between each building")]
+        public float spacing = 10f;
+        [Tooltip("Available building prefabs")]
+        public GameObject[] buildingPrefabs;
+
+        [Tooltip("Optional landmark building prefab for the city center")]
+        public GameObject specialBuildingPrefab;
+
+        [Header("Building Height Settings")]
+        public int edgeMinHeight = 1;
+        public int edgeMaxHeight = 4;
+        public int centerMinHeight = 8;
+        public int centerMaxHeight = 20;
+
+        public float buildDelaySeconds = 0.1f;
+
+        void Start()
+        {
+            Generate();
+        }
+
+        void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.G))
+            {
+                Clear();
+                Generate();
+            }
+        }
+
+        void Clear()
+        {
+            for (int i = transform.childCount - 1; i >= 0; i--)
+            {
+                Destroy(transform.GetChild(i).gameObject);
+            }
+        }
+
+        void Generate()
+        {
+            if (buildingPrefabs == null || buildingPrefabs.Length == 0)
+                return;
+
+            Vector2 center = new Vector2((width - 1) * 0.5f, (depth - 1) * 0.5f);
+            float maxDistance = Vector2.Distance(Vector2.zero, center);
+
+            int landmarkX = width / 2;
+            int landmarkZ = depth / 2;
+
+            for (int x = 0; x < width; x++)
+            {
+                for (int z = 0; z < depth; z++)
+                {
+                    bool isLandmark = x == landmarkX && z == landmarkZ && specialBuildingPrefab != null;
+
+                    GameObject prefab = isLandmark ? specialBuildingPrefab : buildingPrefabs[Random.Range(0, buildingPrefabs.Length)];
+                    GameObject building = Instantiate(prefab, transform);
+
+                    float posX = x * spacing + Random.Range(-spacing * 0.4f, spacing * 0.4f);
+                    float posZ = z * spacing + Random.Range(-spacing * 0.4f, spacing * 0.4f);
+
+                    building.transform.localPosition = new Vector3(posX, 0f, posZ);
+                    building.transform.Rotate(0f, Random.Range(0f, 360f), 0f);
+
+                    float dist = Vector2.Distance(new Vector2(x, z), center);
+                    float t = 1f - dist / maxDistance;
+
+                    int minH = Mathf.RoundToInt(Mathf.Lerp(edgeMinHeight, centerMinHeight, t));
+                    int maxH = Mathf.RoundToInt(Mathf.Lerp(edgeMaxHeight, centerMaxHeight, t));
+
+                    if (isLandmark)
+                    {
+                        minH = centerMaxHeight;
+                        maxH = centerMaxHeight + 10;
+                    }
+
+                    SimpleBuilding simple = building.GetComponent<SimpleBuilding>();
+                    if (simple != null)
+                    {
+                        simple.minHeight = minH;
+                        simple.maxHeight = maxH;
+                    }
+
+                    Shape shape = building.GetComponent<Shape>();
+                    if (shape != null)
+                    {
+                        shape.Generate(buildDelaySeconds);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs.meta
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62d75dc7b1b34c5fb82f304b60b40239
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/FantasyVillageGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/FantasyVillageGenerator.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+
+namespace Demo
+{
+    // Generates a small fantasy village inspired by classic RPG towns.
+    // Houses are placed around a central plaza and oriented randomly.
+    public class FantasyVillageGenerator : MonoBehaviour
+    {
+        [Tooltip("Number of houses to spawn in the village")]
+        public int houseCount = 12;
+        [Tooltip("Maximum radius of the village")]
+        public float radius = 25f;
+        [Tooltip("Available house prefabs")]
+        public GameObject[] housePrefabs;
+
+        public float buildDelaySeconds = 0.1f;
+
+        void Start()
+        {
+            Generate();
+        }
+
+        void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.G))
+            {
+                Clear();
+                Generate();
+            }
+        }
+
+        void Clear()
+        {
+            for (int i = 0; i < transform.childCount; i++)
+            {
+                Destroy(transform.GetChild(i).gameObject);
+            }
+        }
+
+        void Generate()
+        {
+            if (housePrefabs == null || housePrefabs.Length == 0)
+                return;
+
+            for (int i = 0; i < houseCount; i++)
+            {
+                int prefabIndex = Random.Range(0, housePrefabs.Length);
+                GameObject house = Instantiate(housePrefabs[prefabIndex], transform);
+
+                float angle = (i / (float)houseCount) * Mathf.PI * 2f;
+                float distance = Random.Range(radius * 0.4f, radius);
+                Vector3 position = new Vector3(Mathf.Cos(angle), 0, Mathf.Sin(angle)) * distance;
+
+                house.transform.localPosition = position;
+                house.transform.Rotate(0f, Random.Range(0f, 360f), 0f);
+
+                Shape shape = house.GetComponent<Shape>();
+                if (shape != null)
+                {
+                    shape.Generate(buildDelaySeconds);
+                }
+            }
+        }
+    }
+}

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/FantasyVillageGenerator.cs.meta
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/FantasyVillageGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 956ae0be9614493aba5cb48587addf90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ModularMeshes2025_SVC/README.md
+++ b/ModularMeshes2025_SVC/README.md
@@ -1,0 +1,23 @@
+# Procedural City Generators
+
+This Unity project shows how to create small reimagined locations with simple procedural techniques.
+Two example generators are included:
+
+- **FantasyVillageGenerator** – spawns houses radially around a central plaza.
+- **CyberCityBlockGenerator** – creates a dense city block. Building heights decrease away from the center and an optional landmark tower can be spawned.
+
+## Getting Started
+1. Open the project in **Unity 2022.3** or newer.
+2. Create a new empty scene or duplicate an existing one.
+3. Add an empty GameObject and attach either generator script.
+4. Assign one or more modular prefabs to the script.
+   Press **G** during play mode to regenerate the layout.
+5. To create a landmark tower, assign a prefab with a `LandmarkTower` component to
+   the `specialBuildingPrefab` field of `CyberCityBlockGenerator`.
+
+## Files
+- `Assets/Scripts/GeneralScripts/FantasyVillageGenerator.cs`
+- `Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs`
+- `Assets/Scripts/ExampleGrammars/LandmarkTower/LandmarkTower.cs`
+
+These examples build upon the supplied modular meshes and grammar-based generators in the repository.


### PR DESCRIPTION
## Summary
- extend `CyberCityBlockGenerator` to scale building heights by distance and spawn a landmark
- add new `LandmarkTower` grammar as a simple tall tower example
- document landmark usage in README

## Testing
- `git status --short`
- `git log -1 --stat`