### PR TITLE
Add block generator independent from roads

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scenes/GridCity.unity
+++ b/ModularMeshes2025_SVC/Assets/Scenes/GridCity.unity
@@ -333,7 +333,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1087066582}
-  - component: {fileID: 1087066581}
   - component: {fileID: 1087066583}
   - component: {fileID: 1087066584}
   m_Layer: 0
@@ -343,26 +342,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1087066581
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1087066580}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d4a3bb68da96a0b46b33ef8e99bb0ccb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rows: 10
-  columns: 10
-  rowWidth: 7
-  columnWidth: 7
-  buildingPrefabs:
-  - {fileID: 3604920485432597347, guid: fee6c2ac503a81e4cb074a72365b79d0, type: 3}
-  - {fileID: 8345122083041106082, guid: fd916cd3aaf80ac4db38da93574822e1, type: 3}
-  buildDelaySeconds: 0.1
 --- !u!4 &1087066582
 Transform:
   m_ObjectHideFlags: 0
@@ -390,20 +369,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62d75dc7b1b34c5fb82f304b60b40239, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  width: 6
-  depth: 6
-  spacing: 10
   buildingPrefabs:
   - {fileID: 3604920485432597347, guid: fee6c2ac503a81e4cb074a72365b79d0, type: 3}
   - {fileID: 8345122083041106082, guid: fd916cd3aaf80ac4db38da93574822e1, type: 3}
-  specialBuildingPrefab: {fileID: 0}
-  roadPrefab: {fileID: 0}
-  edgeMinHeight: 1
-  edgeMaxHeight: 4
-  centerMinHeight: 8
-  centerMaxHeight: 20
-  buildDelaySeconds: 0.1
-  buildingOffsetFromRoad: 4
+  spacing: 2
+  sidewalkWidth: 3
+  buildDelaySeconds: 0.05
+  minHeight: 1
+  maxHeight: 5
 --- !u!114 &1087066584
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/ModularMeshes2025_SVC/Assets/Scripts/Editor/CyberCityBlockGeneratorEditor.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/Editor/CyberCityBlockGeneratorEditor.cs
@@ -15,19 +15,14 @@ public class CyberCityBlockGeneratorEditor : UnityEditor.Editor
         GUILayout.Space(10);
         EditorGUILayout.LabelField("Generation Tools", EditorStyles.boldLabel);
 
-        if (GUILayout.Button("Clear Scene"))
+        if (GUILayout.Button("Clear Blocks"))
         {
-            generator.ClearScene();
+            generator.ClearBlocks();
         }
 
-        if (GUILayout.Button("Generate Roads"))
+        if (GUILayout.Button("Generate Blocks"))
         {
-            generator.GenerateRoads();
-        }
-
-        if (GUILayout.Button("Generate Town"))
-        {
-            generator.GenerateTown();
+            generator.GenerateBlocks();
         }
     }
 }

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/CityBlockGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/CityBlockGenerator.cs
@@ -1,0 +1,50 @@
+using Demo;
+using UnityEngine;
+
+public class CityBlockGenerator : MonoBehaviour
+{
+    public RectInt bounds;
+    public GameObject[] buildingPrefabs;
+    public float sidewalkWidth = 2f;
+    public float spacing = 8f;
+    public float buildDelaySeconds = 0.1f;
+
+    public void Generate()
+    {
+        for (float x = bounds.xMin + sidewalkWidth; x <= bounds.xMax - sidewalkWidth; x += spacing)
+        {
+            for (float z = bounds.yMin + sidewalkWidth; z <= bounds.yMax - sidewalkWidth; z += spacing)
+            {
+                Vector3 position = new Vector3(x, 0f, z);
+                PlaceBuilding(position);
+            }
+        }
+    }
+
+    void PlaceBuilding(Vector3 position)
+    {
+        if (buildingPrefabs == null || buildingPrefabs.Length == 0)
+            return;
+
+        GameObject prefab = buildingPrefabs[Random.Range(0, buildingPrefabs.Length)];
+        GameObject building = Instantiate(prefab, position, Quaternion.identity, transform);
+
+        float left = position.x - bounds.xMin;
+        float right = bounds.xMax - position.x;
+        float bottom = position.z - bounds.yMin;
+        float top = bounds.yMax - position.z;
+
+        float min = Mathf.Min(Mathf.Min(left, right), Mathf.Min(top, bottom));
+        Quaternion rotation = Quaternion.identity;
+        if (Mathf.Approximately(min, left)) rotation = Quaternion.Euler(0f, 90f, 0f);
+        else if (Mathf.Approximately(min, right)) rotation = Quaternion.Euler(0f, -90f, 0f);
+        else if (Mathf.Approximately(min, top)) rotation = Quaternion.Euler(0f, 180f, 0f);
+        building.transform.rotation = rotation;
+
+        var shape = building.GetComponent<Shape>();
+        if (shape != null)
+        {
+            shape.Generate(buildDelaySeconds);
+        }
+    }
+}

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/CityBlockGenerator.cs.meta
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/CityBlockGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6dc2d438ccd3342f7a1b90253238f885

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/StreetGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/StreetGenerator.cs
@@ -21,12 +21,15 @@ public class CityRoadGenerator : MonoBehaviour
     public float roadThickness = 8f;
     public int overlap = 1;
 
+
     private BSPNode rootNode;
     private List<Room> allBlocks = new();
     private List<Vector2Int> crosswalks = new();
 
     private Transform roadParent;
     private Transform crosswalkParent;
+
+    public IReadOnlyList<Room> Rooms => allBlocks;
 
     public static CityRoadGenerator Instance { get; private set; }
     
@@ -40,7 +43,6 @@ public class CityRoadGenerator : MonoBehaviour
     {
         roadParent = new GameObject("Roads").transform;
         crosswalkParent = new GameObject("Crosswalks").transform;
-
         rootNode = new BSPNode { Bounds = initialBounds };
         Split(rootNode, maxDepth);
         CreateBlocks(rootNode);
@@ -174,6 +176,7 @@ public class CityRoadGenerator : MonoBehaviour
             CreateCrosswalk(crosswalk);
         }
     }
+
 
     void CreatePerimeterRoads(RectInt bounds)
     {


### PR DESCRIPTION
## Summary
- expose generated Rooms via `CityRoadGenerator.Rooms`
- create `CyberCityBlockGenerator` for placing buildings after roads
- update custom editor to use the new generator API

## Testing
- `mcs -version` (failed: command not found)
- `csc` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68605f42fb6c8320830123d271075b1a