### PR TITLE
Ensure street generation resets state

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scripts/Editor/StreetGeneratorEditor.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/Editor/StreetGeneratorEditor.cs
@@ -16,8 +16,7 @@ public class StreetGeneratorEditor : Editor
 
         if (GUILayout.Button("Generate City Roads"))
         {
-            // restart generation
-            generator.Start();
+            generator.GenerateCityRoads();
         }
 
         if (GUILayout.Button("Clear All"))

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/StreetGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/StreetGenerator.cs
@@ -41,6 +41,13 @@ public class CityRoadGenerator : MonoBehaviour
     
     public void Start()
     {
+        GenerateCityRoads();
+    }
+
+    public void GenerateCityRoads()
+    {
+        ClearAll();
+
         roadParent = new GameObject("Roads").transform;
         crosswalkParent = new GameObject("Crosswalks").transform;
         rootNode = new BSPNode { Bounds = initialBounds };
@@ -251,6 +258,7 @@ public class CityRoadGenerator : MonoBehaviour
         roadParent = null;
         crosswalkParent = null;
 
+        rootNode = null;
         allBlocks.Clear();
         crosswalks.Clear();
     }


### PR DESCRIPTION
## Summary
- add a dedicated `GenerateCityRoads` method that clears any existing road parents and block lists before rebuilding the BSP tree
- update the custom editor button to call the new method so repeated generations always start from a clean slate

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2bb46e208320992fd5cdb1fe1c78)