### PR TITLE
Align building placement to world units

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
@@ -35,28 +35,42 @@ namespace GeneralScripts
             if (roadGen == null)
                 return;
 
+            float cellSize = Mathf.Max(roadGen.CellSize, 0.001f);
+
             foreach (Room room in roadGen.Rooms)
             {
                 RectInt inner = new RectInt(room.Bounds.xMin + 1, room.Bounds.yMin + 1,
                     room.Bounds.width - 2, room.Bounds.height - 2);
-                GenerateForRoom(inner);
+                GenerateForRoom(inner, cellSize);
             }
         }
 
-        void GenerateForRoom(RectInt bounds)
+        void GenerateForRoom(RectInt bounds, float cellSize)
         {
-            for (float x = bounds.xMin + sidewalkWidth; x <= bounds.xMax - sidewalkWidth; x += spacing)
+            Rect worldBounds = new Rect(
+                bounds.xMin * cellSize,
+                bounds.yMin * cellSize,
+                bounds.width * cellSize,
+                bounds.height * cellSize);
+
+            float worldSidewalk = Mathf.Max(0f, sidewalkWidth);
+            float worldSpacing = Mathf.Max(spacing, 0.001f);
+
+            if (worldBounds.width <= worldSidewalk * 2f || worldBounds.height <= worldSidewalk * 2f)
+                return;
+
+            for (float x = worldBounds.xMin + worldSidewalk; x <= worldBounds.xMax - worldSidewalk; x += worldSpacing)
             {
-                for (float z = bounds.yMin + sidewalkWidth; z <= bounds.yMax - sidewalkWidth; z += spacing)
+                for (float z = worldBounds.yMin + worldSidewalk; z <= worldBounds.yMax - worldSidewalk; z += worldSpacing)
                 {
                     Vector3 pos = new Vector3(x, 0f, z);
-                    Quaternion rotation = CalculateRotation(bounds, pos);
+                    Quaternion rotation = CalculateRotation(worldBounds, pos);
                     PlaceBuilding(pos, rotation);
                 }
             }
         }
 
-        Quaternion CalculateRotation(RectInt bounds, Vector3 pos)
+        Quaternion CalculateRotation(Rect bounds, Vector3 pos)
         {
             float left = pos.x - bounds.xMin;
             float right = bounds.xMax - pos.x;

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
@@ -75,7 +75,11 @@ namespace GeneralScripts
                 bounds.height * cellSize);
 
             float worldSidewalk = Mathf.Max(0f, sidewalkWidth);
-            float worldSpacing = Mathf.Max(spacing, 0.001f);
+
+            // Treat non-positive spacing values as "fill one building per cell" so users can safely
+            // dial the inspector down to zero without creating an infinite placement loop.
+            float worldSpacing = spacing > 0f ? spacing : cellSize;
+            worldSpacing = Mathf.Max(worldSpacing, 0.01f);
 
             if (worldBounds.width <= worldSidewalk * 2f || worldBounds.height <= worldSidewalk * 2f)
                 return;

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/StreetGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/StreetGenerator.cs
@@ -35,6 +35,8 @@ public class CityRoadGenerator : MonoBehaviour
 
     public IReadOnlyList<Room> Rooms => allBlocks;
 
+    public float CellSize => roadThickness;
+
     public static CityRoadGenerator Instance { get; private set; }
     
     private void Awake()
@@ -53,7 +55,9 @@ public class CityRoadGenerator : MonoBehaviour
         ClearAll();
 
         roadParent = new GameObject("Roads").transform;
+        roadParent.SetParent(transform, false);
         crosswalkParent = new GameObject("Crosswalks").transform;
+        crosswalkParent.SetParent(transform, false);
         rootNode = new BSPNode { Bounds = initialBounds };
         Split(rootNode, maxDepth);
         CreateBlocks(rootNode);


### PR DESCRIPTION
## Summary
- reuse the road generator's cell size to convert city block bounds and sidewalk offsets into meters before spawning buildings
- ensure crosswalk and road parents inherit the generator transform so moving the generator moves every spawned road segment

## Testing
- not run (not supported in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc6ca480883208e747bb63adf0159)