### PR TITLE
Add mesh combining to SimpleBuilding

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
@@ -16,6 +16,7 @@ namespace Demo {
                 public bool combineMeshes = true;
 
                 bool meshesCombined = false;
+                static readonly HashSet<string> nonReadableMeshWarnings = new HashSet<string>();
 
                 int stockNumber = 0; // The number of stocks that have already been spawned below this
 
@@ -122,7 +123,10 @@ namespace Demo {
                                 // marked as readable. Skip those meshes so the combine
                                 // pass can still succeed for the remaining pieces.
                                 if (!filter.sharedMesh.isReadable) {
-                                        Debug.LogWarning($"[SimpleBuilding] Skipping non-readable mesh '{filter.sharedMesh.name}' on '{filter.name}'. Enable Read/Write to include it in the combined mesh.");
+                                        string warningKey = $"{filter.sharedMesh.name}:{filter.name}";
+                                        if (nonReadableMeshWarnings.Add(warningKey)) {
+                                                Debug.LogWarning($"[SimpleBuilding] Skipping non-readable mesh '{filter.sharedMesh.name}' on '{filter.name}'. Enable Read/Write to include it in the combined mesh.");
+                                        }
                                         continue;
                                 }
 

--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
@@ -118,6 +118,14 @@ namespace Demo {
                                 if (filter.sharedMesh==null)
                                         continue;
 
+                                // Unity throws if we try to combine a mesh that is not
+                                // marked as readable. Skip those meshes so the combine
+                                // pass can still succeed for the remaining pieces.
+                                if (!filter.sharedMesh.isReadable) {
+                                        Debug.LogWarning($"[SimpleBuilding] Skipping non-readable mesh '{filter.sharedMesh.name}' on '{filter.name}'. Enable Read/Write to include it in the combined mesh.");
+                                        continue;
+                                }
+
                                 MeshRenderer childRenderer = filter.GetComponent<MeshRenderer>();
                                 if (childRenderer==null)
                                         continue;

--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
@@ -1,17 +1,23 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 namespace Demo {
-	public class SimpleBuilding : Shape {
-		public int buildingHeight=-1; // The total building height (=#stocks) - value should be the same for all stocks
-		public float stockHeight=1; // The height of one stock. Change this value depending on the height of your stock prefabs
-		// If buildingHeight is negative, a random building height will be chosen between these two limits:
-		public int maxHeight=5;  
-		public int minHeight=1; 
-		
-		public GameObject[] stockPrefabs; // Your stock prefabs (make sure they all have the same height)
-		public GameObject[] roofPrefabs; // Your roof prefabs (may have different height)
+        public class SimpleBuilding : Shape {
+                public int buildingHeight=-1; // The total building height (=#stocks) - value should be the same for all stocks
+                public float stockHeight=1; // The height of one stock. Change this value depending on the height of your stock prefabs
+                // If buildingHeight is negative, a random building height will be chosen between these two limits:
+                public int maxHeight=5;
+                public int minHeight=1;
 
-		int stockNumber = 0; // The number of stocks that have already been spawned below this
+                public GameObject[] stockPrefabs; // Your stock prefabs (make sure they all have the same height)
+                public GameObject[] roofPrefabs; // Your roof prefabs (may have different height)
+
+                [SerializeField]
+                bool combineMeshes = true;
+
+                bool meshesCombined = false;
+
+                int stockNumber = 0; // The number of stocks that have already been spawned below this
 
 		public void Initialize(int pBuildingHeight, float pStockHeight, int pStockNumber, GameObject[] pStockPrefabs, GameObject[] pRoofPrefabs) {
 			buildingHeight = pBuildingHeight;
@@ -27,10 +33,13 @@ namespace Demo {
 			return choices[index];
 		}
 
-		protected override void Execute() {
-			if (buildingHeight<0) { // This is only done once for the root symbol
-				buildingHeight = Random.Range(minHeight, maxHeight+1);
-			}
+                protected override void Execute() {
+                        if (stockNumber==0 && Root==gameObject) {
+                                ResetCombinedMeshState();
+                        }
+                        if (buildingHeight<0) { // This is only done once for the root symbol
+                                buildingHeight = Random.Range(minHeight, maxHeight+1);
+                        }
 
 			if (stockNumber<buildingHeight) { 
 				// First spawn a new stock...
@@ -41,13 +50,111 @@ namespace Demo {
 				// Create a new symbol - make sure to increase the y-coordinate:
 				SimpleBuilding remainingBuilding = CreateSymbol<SimpleBuilding>("stock", new Vector3(0, stockHeight, 0));
 				// Pass the parameters to the new symbol (component), but increase the stockNumber:
-				remainingBuilding.Initialize(buildingHeight, stockHeight, stockNumber+1, stockPrefabs, roofPrefabs);
+                                remainingBuilding.Initialize(buildingHeight, stockHeight, stockNumber+1, stockPrefabs, roofPrefabs);
+                                remainingBuilding.combineMeshes = combineMeshes;
 				// ...and continue with the shape grammar:
 				remainingBuilding.Generate(buildDelay);
-			} else {
-				// Spawn a roof and stop:
-				GameObject newRoof = SpawnPrefab(ChooseRandom(roofPrefabs));
-			}
-		}
-	}
+                        } else {
+                                // Spawn a roof and stop:
+                                GameObject newRoof = SpawnPrefab(ChooseRandom(roofPrefabs));
+
+                                if (combineMeshes) {
+                                        SimpleBuilding rootBuilding = Root.GetComponent<SimpleBuilding>();
+                                        if (rootBuilding!=null) {
+                                                rootBuilding.CombineGeneratedMeshes();
+                                        }
+                                }
+                        }
+                }
+
+                void ResetCombinedMeshState() {
+                        if (Root!=gameObject)
+                                return;
+
+                        MeshFilter rootFilter = GetComponent<MeshFilter>();
+                        if (rootFilter!=null && rootFilter.sharedMesh!=null) {
+                                if (Application.isPlaying) {
+                                        Destroy(rootFilter.sharedMesh);
+                                } else {
+                                        DestroyImmediate(rootFilter.sharedMesh);
+                                }
+                                rootFilter.sharedMesh=null;
+                        }
+
+                        MeshRenderer rootRenderer = GetComponent<MeshRenderer>();
+                        if (rootRenderer!=null) {
+                                rootRenderer.sharedMaterial=null;
+                        }
+
+                        MeshCollider rootCollider = GetComponent<MeshCollider>();
+                        if (rootCollider!=null) {
+                                rootCollider.sharedMesh=null;
+                        }
+
+                        meshesCombined=false;
+                }
+
+                void CombineGeneratedMeshes() {
+                        if (!combineMeshes || meshesCombined || Root!=gameObject)
+                                return;
+
+                        MeshFilter[] meshFilters = GetComponentsInChildren<MeshFilter>();
+                        if (meshFilters==null || meshFilters.Length==0)
+                                return;
+
+                        List<CombineInstance> combineInstances = new List<CombineInstance>();
+                        Material sharedMaterial = null;
+                        Transform rootTransform = transform;
+
+                        foreach (MeshFilter filter in meshFilters) {
+                                if (filter.transform==rootTransform)
+                                        continue;
+                                if (filter.sharedMesh==null)
+                                        continue;
+
+                                MeshRenderer childRenderer = filter.GetComponent<MeshRenderer>();
+                                if (childRenderer==null)
+                                        continue;
+
+                                CombineInstance instance = new CombineInstance {
+                                        mesh = filter.sharedMesh,
+                                        transform = rootTransform.worldToLocalMatrix * filter.transform.localToWorldMatrix
+                                };
+                                combineInstances.Add(instance);
+
+                                if (sharedMaterial==null && childRenderer.sharedMaterial!=null) {
+                                        sharedMaterial = childRenderer.sharedMaterial;
+                                }
+
+                                childRenderer.enabled=false;
+                        }
+
+                        if (combineInstances.Count==0)
+                                return;
+
+                        MeshFilter rootFilter = GetComponent<MeshFilter>();
+                        if (rootFilter==null)
+                                rootFilter = gameObject.AddComponent<MeshFilter>();
+
+                        MeshRenderer rootRenderer = GetComponent<MeshRenderer>();
+                        if (rootRenderer==null)
+                                rootRenderer = gameObject.AddComponent<MeshRenderer>();
+
+                        Mesh combinedMesh = new Mesh();
+                        combinedMesh.CombineMeshes(combineInstances.ToArray(), true, true);
+                        rootFilter.sharedMesh = combinedMesh;
+
+                        if (sharedMaterial!=null) {
+                                rootRenderer.sharedMaterial = sharedMaterial;
+                        }
+
+                        MeshCollider rootCollider = GetComponent<MeshCollider>();
+                        if (rootCollider==null)
+                                rootCollider = gameObject.AddComponent<MeshCollider>();
+                        rootCollider.sharedMesh = null;
+                        rootCollider.sharedMesh = combinedMesh;
+
+                        meshesCombined=true;
+                }
+        }
 }

--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
@@ -13,7 +13,7 @@ namespace Demo {
                 public GameObject[] roofPrefabs; // Your roof prefabs (may have different height)
 
                 [SerializeField]
-                bool combineMeshes = true;
+                public bool combineMeshes = true;
 
                 bool meshesCombined = false;
 
@@ -91,6 +91,11 @@ namespace Demo {
                                 rootCollider.sharedMesh=null;
                         }
 
+                        MeshRenderer[] childRenderers = GetComponentsInChildren<MeshRenderer>();
+                        foreach (MeshRenderer childRenderer in childRenderers) {
+                                childRenderer.enabled=true;
+                        }
+
                         meshesCombined=false;
                 }
 
@@ -103,7 +108,8 @@ namespace Demo {
                                 return;
 
                         List<CombineInstance> combineInstances = new List<CombineInstance>();
-                        Material sharedMaterial = null;
+                        List<MeshRenderer> childRenderers = new List<MeshRenderer>();
+                        Material[] sharedMaterials = null;
                         Transform rootTransform = transform;
 
                         foreach (MeshFilter filter in meshFilters) {
@@ -122,11 +128,11 @@ namespace Demo {
                                 };
                                 combineInstances.Add(instance);
 
-                                if (sharedMaterial==null && childRenderer.sharedMaterial!=null) {
-                                        sharedMaterial = childRenderer.sharedMaterial;
+                                if (sharedMaterials==null && childRenderer.sharedMaterials!=null && childRenderer.sharedMaterials.Length>0) {
+                                        sharedMaterials = childRenderer.sharedMaterials;
                                 }
 
-                                childRenderer.enabled=false;
+                                childRenderers.Add(childRenderer);
                         }
 
                         if (combineInstances.Count==0)
@@ -144,8 +150,8 @@ namespace Demo {
                         combinedMesh.CombineMeshes(combineInstances.ToArray(), true, true);
                         rootFilter.sharedMesh = combinedMesh;
 
-                        if (sharedMaterial!=null) {
-                                rootRenderer.sharedMaterial = sharedMaterial;
+                        if (sharedMaterials!=null) {
+                                rootRenderer.sharedMaterials = sharedMaterials;
                         }
 
                         MeshCollider rootCollider = GetComponent<MeshCollider>();
@@ -153,6 +159,10 @@ namespace Demo {
                                 rootCollider = gameObject.AddComponent<MeshCollider>();
                         rootCollider.sharedMesh = null;
                         rootCollider.sharedMesh = combinedMesh;
+
+                        foreach (MeshRenderer childRenderer in childRenderers) {
+                                childRenderer.enabled=false;
+                        }
 
                         meshesCombined=true;
                 }


### PR DESCRIPTION
## Summary
- add an optional mesh-combining pass to `SimpleBuilding` so completed buildings collapse to a single renderer and collider
- reset the root mesh state before spawning new floors to avoid showing stale geometry between generations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de8aa0d808320a092012892e7121c)