### PR TITLE
Center building placement within sidewalks

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
@@ -74,8 +74,8 @@ namespace GeneralScripts
                 bounds.width * cellSize,
                 bounds.height * cellSize);
 
-            float worldSidewalk = Mathf.Max(0f, sidewalkWidth);
             float worldSpacing = Mathf.Max(spacing, 0.001f);
+            float worldSidewalk = Mathf.Max(worldSpacing * 0.5f, sidewalkWidth);
 
             if (worldBounds.width <= worldSidewalk * 2f || worldBounds.height <= worldSidewalk * 2f)
                 return;

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/CyberCityBlockGenerator.cs
@@ -80,11 +80,23 @@ namespace GeneralScripts
             if (worldBounds.width <= worldSidewalk * 2f || worldBounds.height <= worldSidewalk * 2f)
                 return;
 
-            for (float x = worldBounds.xMin + worldSidewalk; x <= worldBounds.xMax - worldSidewalk; x += worldSpacing)
+            float usableWidth = worldBounds.width - (worldSidewalk * 2f);
+            float usableHeight = worldBounds.height - (worldSidewalk * 2f);
+
+            int stepsX = Mathf.Max(1, Mathf.FloorToInt(usableWidth / worldSpacing) + 1);
+            int stepsZ = Mathf.Max(1, Mathf.FloorToInt(usableHeight / worldSpacing) + 1);
+
+            float leftoverX = Mathf.Max(0f, usableWidth - ((stepsX - 1) * worldSpacing));
+            float leftoverZ = Mathf.Max(0f, usableHeight - ((stepsZ - 1) * worldSpacing));
+
+            float startX = worldBounds.xMin + worldSidewalk + (leftoverX * 0.5f);
+            float startZ = worldBounds.yMin + worldSidewalk + (leftoverZ * 0.5f);
+
+            for (int ix = 0; ix < stepsX; ix++)
             {
-                for (float z = worldBounds.yMin + worldSidewalk; z <= worldBounds.yMax - worldSidewalk; z += worldSpacing)
+                for (int iz = 0; iz < stepsZ; iz++)
                 {
-                    Vector3 pos = new Vector3(x, 0f, z);
+                    Vector3 pos = new Vector3(startX + (ix * worldSpacing), 0f, startZ + (iz * worldSpacing));
                     Quaternion rotation = CalculateRotation(worldBounds, pos);
                     PlaceBuilding(pos, rotation, parent);
                 }

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/CityBlockGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/CityBlockGenerator.cs
@@ -11,11 +11,26 @@ public class CityBlockGenerator : MonoBehaviour
 
     public void Generate()
     {
-        for (float x = bounds.xMin + sidewalkWidth; x <= bounds.xMax - sidewalkWidth; x += spacing)
+        float usableWidth = bounds.width - (sidewalkWidth * 2f);
+        float usableHeight = bounds.height - (sidewalkWidth * 2f);
+
+        if (usableWidth <= 0f || usableHeight <= 0f)
+            return;
+
+        int stepsX = Mathf.Max(1, Mathf.FloorToInt(usableWidth / spacing) + 1);
+        int stepsZ = Mathf.Max(1, Mathf.FloorToInt(usableHeight / spacing) + 1);
+
+        float leftoverX = Mathf.Max(0f, usableWidth - ((stepsX - 1) * spacing));
+        float leftoverZ = Mathf.Max(0f, usableHeight - ((stepsZ - 1) * spacing));
+
+        float startX = bounds.xMin + sidewalkWidth + (leftoverX * 0.5f);
+        float startZ = bounds.yMin + sidewalkWidth + (leftoverZ * 0.5f);
+
+        for (int ix = 0; ix < stepsX; ix++)
         {
-            for (float z = bounds.yMin + sidewalkWidth; z <= bounds.yMax - sidewalkWidth; z += spacing)
+            for (int iz = 0; iz < stepsZ; iz++)
             {
-                Vector3 position = new Vector3(x, 0f, z);
+                Vector3 position = new Vector3(startX + (ix * spacing), 0f, startZ + (iz * spacing));
                 PlaceBuilding(position);
             }
         }

--- a/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/CityBlockGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/GeneralScripts/Roads/CityBlockGenerator.cs
@@ -11,8 +11,10 @@ public class CityBlockGenerator : MonoBehaviour
 
     public void Generate()
     {
-        float usableWidth = bounds.width - (sidewalkWidth * 2f);
-        float usableHeight = bounds.height - (sidewalkWidth * 2f);
+        float effectiveSidewalk = Mathf.Max(sidewalkWidth, spacing * 0.5f);
+
+        float usableWidth = bounds.width - (effectiveSidewalk * 2f);
+        float usableHeight = bounds.height - (effectiveSidewalk * 2f);
 
         if (usableWidth <= 0f || usableHeight <= 0f)
             return;
@@ -23,8 +25,8 @@ public class CityBlockGenerator : MonoBehaviour
         float leftoverX = Mathf.Max(0f, usableWidth - ((stepsX - 1) * spacing));
         float leftoverZ = Mathf.Max(0f, usableHeight - ((stepsZ - 1) * spacing));
 
-        float startX = bounds.xMin + sidewalkWidth + (leftoverX * 0.5f);
-        float startZ = bounds.yMin + sidewalkWidth + (leftoverZ * 0.5f);
+        float startX = bounds.xMin + effectiveSidewalk + (leftoverX * 0.5f);
+        float startZ = bounds.yMin + effectiveSidewalk + (leftoverZ * 0.5f);
 
         for (int ix = 0; ix < stepsX; ix++)
         {


### PR DESCRIPTION
## Summary
- center building grids within the available block area so sidewalks shrink blocks uniformly
- distribute spacing evenly to keep layouts centered in both city and cyber city generators

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69206f00d6848320be759b26d0fd3e0f)