### PR TITLE
Clamp building heights to configured maximum

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/Building/SimpleRoof.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/Building/SimpleRoof.cs
@@ -1,82 +1,97 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace Demo {
-	public class SimpleRoof : Shape {
-		// grammar rule probabilities:
-		const float roofContinueChance = 0.5f;
+        public class SimpleRoof : Shape {
+                // grammar rule probabilities:
+                const float roofContinueChance = 0.5f;
 
-		// shape parameters:
-		int Width;
-		int Depth;
+                // shape parameters:
+                int Width;
+                int Depth;
 
-		GameObject[] roofStyle;
-		GameObject[] wallStyle;
+                GameObject[] roofStyle;
+                GameObject[] wallStyle;
 
-		// (offset) values for the next layer:
-		int newWidth;
-		int newDepth;
+                // (offset) values for the next layer:
+                int newWidth;
+                int newDepth;
 
-		public void Initialize(int Width, int Depth, GameObject[] roofStyle, GameObject[] wallStyle) {
-			this.Width=Width;
-			this.Depth=Depth;
-			this.roofStyle=roofStyle;
-			this.wallStyle=wallStyle;
-		}
+                int currentHeight = 1;
+                int minHeight = 1;
+                int maxHeight = 5;
+
+                public void Initialize(int Width, int Depth, GameObject[] roofStyle, GameObject[] wallStyle, int currentHeight = 1, int minHeight = 1, int maxHeight = 5) {
+                        this.Width=Width;
+                        this.Depth=Depth;
+                        this.roofStyle=roofStyle;
+                        this.wallStyle=wallStyle;
+                        this.currentHeight = currentHeight;
+                        this.minHeight = minHeight;
+                        this.maxHeight = maxHeight;
+                }
 
 
-		protected override void Execute() {
-			if (Width==0 || Depth==0)
-				return;
+                protected override void Execute() {
+                        if (Width==0 || Depth==0)
+                                return;
 
-			newWidth=Width;
-			newDepth=Depth;
+                        newWidth=Width;
+                        newDepth=Depth;
 
-			CreateFlatRoofPart();
-			CreateNextPart();
-		}
+                        CreateFlatRoofPart();
+                        CreateNextPart();
+                }
 
-		void CreateFlatRoofPart() {
-			// Randomly create two roof strips in depth direction or in width direction:
-			int side = RandomInt(2);
-			SimpleRow flatRoof;
+                void CreateFlatRoofPart() {
+                        // Randomly create two roof strips in depth direction or in width direction:
+                        int side = RandomInt(2);
+                        SimpleRow flatRoof;
 
-			switch (side) {
-				// Add two roof strips in depth direction
-				case 0:
-					for (int i = 0; i<2; i++) {
-						flatRoof = CreateSymbol<SimpleRow>("roofStrip",new Vector3((Width-1)*(i-0.5f), 0, 0));
-						flatRoof.Initialize(Depth, roofStyle);
-						flatRoof.Generate();
-					}
-					newWidth-=2;
-					break;
-				// Add two roof strips in width direction
-				case 1:
-					for (int i = 0; i<2; i++) {
-						flatRoof = CreateSymbol<SimpleRow>("roofStrip",new Vector3(0,0,(Depth-1)*(i-0.5f)));
-						flatRoof.Initialize(Width, roofStyle,new Vector3(1,0,0));
-						flatRoof.Generate();
-					}
-					newDepth-=2;
-					break;
-			}
-		}
+                        switch (side) {
+                                // Add two roof strips in depth direction
+                                case 0:
+                                        for (int i = 0; i<2; i++) {
+                                                flatRoof = CreateSymbol<SimpleRow>("roofStrip",new Vector3((Width-1)*(i-0.5f), 0, 0));
+                                                flatRoof.Initialize(Depth, roofStyle);
+                                                flatRoof.Generate();
+                                        }
+                                        newWidth-=2;
+                                        break;
+                                // Add two roof strips in width direction
+                                case 1:
+                                        for (int i = 0; i<2; i++) {
+                                                flatRoof = CreateSymbol<SimpleRow>("roofStrip",new Vector3(0,0,(Depth-1)*(i-0.5f)));
+                                                flatRoof.Initialize(Width, roofStyle,new Vector3(1,0,0));
+                                                flatRoof.Generate();
+                                        }
+                                        newDepth-=2;
+                                        break;
+                        }
+                }
 
-		void CreateNextPart() {
-			// randomly continue with a roof or a stock:
-			if (newWidth<=0 || newDepth<=0)
-				return;
+                void CreateNextPart() {
+                        // randomly continue with a roof or a stock:
+                        if (newWidth<=0 || newDepth<=0)
+                                return;
 
-			float randomValue = RandomFloat();
-			if (randomValue<roofContinueChance) { // continue with the roof
-				SimpleRoof nextRoof = CreateSymbol<SimpleRoof>("roof");
-				nextRoof.Initialize(newWidth, newDepth, roofStyle, wallStyle);
-				nextRoof.Generate(buildDelay);
-			} else { // continue with a stock
-				SimpleStock nextStock = CreateSymbol<SimpleStock>("stock");
-				nextStock.Initialize(newWidth, newDepth, wallStyle, roofStyle);
-				nextStock.Generate(buildDelay);
-			}
-		}
-	}
+                        int cappedMaxHeight = Mathf.Max(minHeight, maxHeight);
+                        int clampedHeight = Mathf.Clamp(currentHeight, 1, cappedMaxHeight);
+                        bool mustContinue = clampedHeight < minHeight;
+                        bool canContinue = clampedHeight < cappedMaxHeight;
+
+                        if (!canContinue)
+                                return;
+
+                        float randomValue = RandomFloat();
+                        if (mustContinue || randomValue<roofContinueChance) { // continue with the roof
+                                SimpleRoof nextRoof = CreateSymbol<SimpleRoof>("roof");
+                                nextRoof.Initialize(newWidth, newDepth, roofStyle, wallStyle, clampedHeight + 1, minHeight, cappedMaxHeight);
+                                nextRoof.Generate(buildDelay);
+                        } else { // continue with a stock
+                                SimpleStock nextStock = CreateSymbol<SimpleStock>("stock");
+                                nextStock.Initialize(newWidth, newDepth, wallStyle, roofStyle, clampedHeight + 1, minHeight, cappedMaxHeight);
+                                nextStock.Generate(buildDelay);
+                        }
+                }
+        }
 }

--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/Building/SimpleStock.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/Building/SimpleStock.cs
@@ -5,27 +5,40 @@ namespace Demo {
 		// grammar rule probabilities:
 		const float stockContinueChance = 0.5f;
 
-		// shape parameters:
-		[SerializeField]
-		int Width;
-		[SerializeField]
-		int Depth;
+                // shape parameters:
+                [SerializeField]
+                int Width;
+                [SerializeField]
+                int Depth;
+
+                [SerializeField]
+                int currentHeight = 1;
+                [SerializeField]
+                int minHeight = 1;
+                [SerializeField]
+                int maxHeight = 5;
 
 		[SerializeField]
 		GameObject[] wallStyle;
 		[SerializeField]
 		GameObject[] roofStyle;
 
-		public void Initialize(int Width, int Depth, GameObject[] wallStyle, GameObject[] roofStyle) {
-			this.Width=Width;
-			this.Depth=Depth;
-			this.wallStyle=wallStyle;
-			this.roofStyle=roofStyle;
-		}
+                public void Initialize(int Width, int Depth, GameObject[] wallStyle, GameObject[] roofStyle, int currentHeight = 1, int minHeight = 1, int maxHeight = 5) {
+                        this.Width=Width;
+                        this.Depth=Depth;
+                        this.wallStyle=wallStyle;
+                        this.roofStyle=roofStyle;
+                        this.currentHeight = currentHeight;
+                        this.minHeight = minHeight;
+                        this.maxHeight = maxHeight;
+                }
 
-		protected override void Execute() {
-			// Create four walls:
-			for (int i = 0; i<4; i++) {
+                protected override void Execute() {
+                        int cappedMaxHeight = Mathf.Max(minHeight, maxHeight);
+                        int clampedHeight = Mathf.Clamp(currentHeight, 1, cappedMaxHeight);
+
+                        // Create four walls:
+                        for (int i = 0; i<4; i++) {
 				Vector3 localPosition = new Vector3();
 				switch (i) {
 					case 0:
@@ -46,17 +59,19 @@ namespace Demo {
 				newRow.Generate();
 			}		
 
-			// Continue with a stock or with a roof (random choice):
-			float randomValue = RandomFloat();
-			if (randomValue < stockContinueChance) {
-				SimpleStock nextStock = CreateSymbol<SimpleStock>("stock", new Vector3(0, 1, 0));
-				nextStock.Initialize(Width, Depth, wallStyle, roofStyle);
-				nextStock.Generate(buildDelay);
-			} else {
-				SimpleRoof nextRoof = CreateSymbol<SimpleRoof>("roof", new Vector3(0, 1, 0));
-				nextRoof.Initialize(Width, Depth, roofStyle,wallStyle);
-				nextRoof.Generate(buildDelay);
-			}
-		}
-	}
+                        // Continue with a stock or with a roof (respecting height limits):
+                        bool mustContinue = clampedHeight < minHeight;
+                        bool canContinue = clampedHeight < cappedMaxHeight;
+
+                        if (canContinue && (mustContinue || RandomFloat() < stockContinueChance)) {
+                                SimpleStock nextStock = CreateSymbol<SimpleStock>("stock", new Vector3(0, 1, 0));
+                                nextStock.Initialize(Width, Depth, wallStyle, roofStyle, clampedHeight + 1, minHeight, cappedMaxHeight);
+                                nextStock.Generate(buildDelay);
+                        } else if (canContinue || clampedHeight >= minHeight) {
+                                SimpleRoof nextRoof = CreateSymbol<SimpleRoof>("roof", new Vector3(0, 1, 0));
+                                nextRoof.Initialize(Width, Depth, roofStyle, wallStyle, clampedHeight, minHeight, cappedMaxHeight);
+                                nextRoof.Generate(buildDelay);
+                        }
+                }
+        }
 }

--- a/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/ExampleGrammars/SimpleBuilding/SimpleBuilding.cs
@@ -27,10 +27,14 @@ namespace Demo {
 			return choices[index];
 		}
 
-		protected override void Execute() {
-			if (buildingHeight<0) { // This is only done once for the root symbol
-				buildingHeight = Random.Range(minHeight, maxHeight+1);
-			}
+                protected override void Execute() {
+                        int cappedMaxHeight = Mathf.Max(minHeight, maxHeight);
+
+                        if (buildingHeight<0) { // This is only done once for the root symbol
+                                buildingHeight = Random.Range(minHeight, cappedMaxHeight+1);
+                        } else {
+                                buildingHeight = Mathf.Clamp(buildingHeight, minHeight, cappedMaxHeight);
+                        }
 
 			if (stockNumber<buildingHeight) { 
 				// First spawn a new stock...


### PR DESCRIPTION
## Summary
- clamp random and fixed building heights to the configured maximum to respect limits
- use min height when max is lower to keep generation stable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692077999d7883208fa777f635bd69d0)