### PR TITLE
Adjust roof height to account for foundations

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scripts/SovietPanel/SovietPanelBuildingGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/SovietPanel/SovietPanelBuildingGenerator.cs
@@ -127,7 +127,7 @@ public class SovietPanelBuildingGenerator : MonoBehaviour
         float zBackShort = (shortFacadeDepth - 1f) * gridSize;
         float xLeft = -gridSize * 0.5f;
         float xRight = (TotalWidth() - 0.5f) * gridSize;
-        float roofY = floors * floorHeight;
+        float roofY = GetFoundationHeight() + floors * floorHeight;
 
         Transform parent = CreateRootParent();
         Transform facadeParent = CreateChild(parent, "Facades");


### PR DESCRIPTION
## Summary
- compute roof placement height using foundation height plus floors to align roof elements with raised bases

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692375c33fc8832088d59c2da4596c08)