### PR TITLE
Adjust roof generation to use ramps per section

### DIFF
--- a/ModularMeshes2025_SVC/Assets/Scripts/SovietPanel/SovietPanelBuildingGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/SovietPanel/SovietPanelBuildingGenerator.cs
@@ -257,29 +257,29 @@ public class SovietPanelBuildingGenerator : MonoBehaviour
 
         Transform roofParent = CreateChild(parent, "Roof");
 
-        for (int facade = 0; facade < 2; facade++)
+        float xCursor = 0f;
+        foreach (SectionLayout layout in sectionLayouts)
         {
-            bool isFront = facade == 0;
-            float zPos = isFront ? zFrontLong : zBackLong;
-            Quaternion inwardRotation = isFront ? Quaternion.identity : Quaternion.Euler(0f, 180f, 0f);
-
-            float xCursor = 0f;
-            foreach (SectionLayout layout in sectionLayouts)
+            for (int localX = 0; localX < layout.width; localX++)
             {
-                for (int localX = 0; localX < layout.width; localX++)
+                for (int depthIndex = 0; depthIndex <= shortFacadeDepth; depthIndex++)
                 {
-                    bool useRamp = localX == 0 || localX == layout.width - 1;
-                    GameObject prefabToUse = useRamp ? roofPrefabs.rampInward : roofPrefabs.flat;
+                    bool isFrontRow = depthIndex == 0;
+                    bool isBackRow = depthIndex == shortFacadeDepth;
+                    GameObject prefabToUse = (isFrontRow || isBackRow) ? roofPrefabs.rampInward : roofPrefabs.flat;
 
                     if (prefabToUse == null)
                         continue;
 
-                    Vector3 bottom = new Vector3((xCursor + localX) * gridSize, roofY, zPos);
-                    InstantiateAligned(prefabToUse, bottom, ApplyRotation(inwardRotation), roofParent);
-                }
+                    float zPos = zFrontLong + depthIndex * gridSize;
+                    Quaternion rotation = isFrontRow ? Quaternion.identity : isBackRow ? Quaternion.Euler(0f, 180f, 0f) : Quaternion.identity;
 
-                xCursor += layout.width;
+                    Vector3 bottom = new Vector3((xCursor + localX) * gridSize, roofY, zPos);
+                    InstantiateAligned(prefabToUse, bottom, ApplyRotation(rotation), roofParent);
+                }
             }
+
+            xCursor += layout.width;
         }
 
         if (roofPrefabs.parapet != null)

--- a/ModularMeshes2025_SVC/Assets/Scripts/SovietPanel/SovietPanelBuildingGenerator.cs
+++ b/ModularMeshes2025_SVC/Assets/Scripts/SovietPanel/SovietPanelBuildingGenerator.cs
@@ -256,7 +256,6 @@ public class SovietPanelBuildingGenerator : MonoBehaviour
             return;
 
         Transform roofParent = CreateChild(parent, "Roof");
-        float totalWidth = TotalWidth();
 
         for (int facade = 0; facade < 2; facade++)
         {
@@ -264,19 +263,22 @@ public class SovietPanelBuildingGenerator : MonoBehaviour
             float zPos = isFront ? zFrontLong : zBackLong;
             Quaternion inwardRotation = isFront ? Quaternion.identity : Quaternion.Euler(0f, 180f, 0f);
 
-            for (int xIndex = 0; xIndex < totalWidth; xIndex++)
+            float xCursor = 0f;
+            foreach (SectionLayout layout in sectionLayouts)
             {
-                GameObject prefabToUse;
-                if (xIndex == 0 || xIndex == totalWidth - 1)
-                    prefabToUse = roofPrefabs.rampInward;
-                else
-                    prefabToUse = roofPrefabs.flat;
+                for (int localX = 0; localX < layout.width; localX++)
+                {
+                    bool useRamp = localX == 0 || localX == layout.width - 1;
+                    GameObject prefabToUse = useRamp ? roofPrefabs.rampInward : roofPrefabs.flat;
 
-                if (prefabToUse == null)
-                    continue;
+                    if (prefabToUse == null)
+                        continue;
 
-                Vector3 bottom = new Vector3(xIndex * gridSize, roofY, zPos);
-                InstantiateAligned(prefabToUse, bottom, ApplyRotation(inwardRotation), roofParent);
+                    Vector3 bottom = new Vector3((xCursor + localX) * gridSize, roofY, zPos);
+                    InstantiateAligned(prefabToUse, bottom, ApplyRotation(inwardRotation), roofParent);
+                }
+
+                xCursor += layout.width;
             }
         }
 


### PR DESCRIPTION
## Summary
- build roof strips per section so each long facade segment is bracketed by ramp modules with flats in between
- remove unused total width variable while iterating through roof sections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692376d857f48320ad86cbe9860303f9)